### PR TITLE
Close #50  - Admin can edit enrollment (created by user)

### DIFF
--- a/src/modules/appointment/appointment.entity.ts
+++ b/src/modules/appointment/appointment.entity.ts
@@ -63,7 +63,10 @@ export class Appointment {
     driverAddition: boolean;
 
     @ManyToMany(type => User,
-        user => user.administrations)
+        user => user.administrations,
+        {
+            eager: true,
+        })
     @JoinTable()
     administrators: User[];
 


### PR DESCRIPTION
Enrollments which are created by a logged in user could not be edited by an administrator.
This was due to the admins not being loaded into the appointment entity by default.
Including an eager loading parameter fixes the issue by provioding the correct list of administrators for the particular appointment.