### PR TITLE
Login returning valid error codes

### DIFF
--- a/src/auth/local.strategy.ts
+++ b/src/auth/local.strategy.ts
@@ -1,6 +1,6 @@
 import {Strategy} from 'passport-local';
 import {PassportStrategy} from '@nestjs/passport';
-import {Injectable, UnauthorizedException} from '@nestjs/common';
+import {Injectable} from '@nestjs/common';
 import {AuthService} from './auth.service';
 
 @Injectable()
@@ -15,7 +15,7 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
         try {
             res = await this.authService.login(mail, password);
         } catch (e) {
-            throw new UnauthorizedException();
+            throw e;
         }
 
         return res;

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -518,7 +518,7 @@ export class UserService {
 
         const passwordChangeListByReset = await this.passwordResetRepository.find({
             where: {
-                oldPassword: IsNull(),
+                oldPassword: !IsNull(),
                 user: {
                     id: user.id
                 }
@@ -539,7 +539,7 @@ export class UserService {
 
         const passwordChangeListByChange = await this.passwordChangeRepository.find({
             where: {
-                oldPassword: IsNull(),
+                oldPassword: !IsNull(),
                 user: {
                     id: user.id
                 }


### PR DESCRIPTION
Upon logging in, the endpoint should return more and clearere erroro codes upon failed login.

ACCOUNT_LOCK with data NOT_ACTIVATED when user account is not activated
INVALID _PASSWORD with the date of the change of this password.

Close #49 